### PR TITLE
update: 自动配置注册迁移

### DIFF
--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=icu.qimuu.qiapisdk.config.QiApiClientConfig

--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+icu.qimuu.qiapisdk.config.QiApiClientConfig


### PR DESCRIPTION
自动配置注册迁移到 `AutoConfiguration`下的`imports`
> `spring.factories`不推荐从加载自动配置
Spring Boot 2.7 发行说明：https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.7-Release-Notes